### PR TITLE
update object pointcloud topic for input to grasp synthesis

### DIFF
--- a/models/tsgrasp_scene_1_frame/metadata.yaml
+++ b/models/tsgrasp_scene_1_frame/metadata.yaml
@@ -32,7 +32,7 @@ model:
 
 # ROS Specific Parameters
 ckpt_path: src/grasp_synthesis/tsgrasp/models/tsgrasp_scene_1_frame/model.ckpt # relative to pkg_root
-pc_topic: /point_cloud_cropper/cropped_pc
+pc_topic: /filter_operations_node/object_pc
 queue_len: 1
 outlier_threshold: 0.00005
 pts_per_frame: 45000


### PR DESCRIPTION
When using the raven_manip_sw launch files, the object detection wasn't connected to the grasp synthesis.
`mon launch raven_manip_sw perception.launch start_detector:=true`
`mon launch raven_manip_sw grasping.launch`

@micat001 -- sending this one-line MR to you rather than merging directly because:
1) I'm not positive that this is the right place to change the plumbing
2) I don't want to break your launch files, since presumably you have something that's working